### PR TITLE
Add CI/CD pipeline with Traefik and self-hosted deploy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,62 @@
+name: build-image
+on:
+  push:
+    branches: [main, dev]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  docker:
+    runs-on: self-hosted
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Detect build dir (dist or build)
+        id: detect
+        shell: bash
+        run: |
+          node -e "const p=require('./package.json'); \
+            const hasVite = (p.devDependencies&&p.devDependencies.vite)||(p.dependencies&&p.dependencies.vite); \
+            console.log('BUILD_DIR='+(hasVite?'dist':'build'))" >> $GITHUB_OUTPUT
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Compute tags
+        id: tags
+        run: |
+          SHA=${GITHUB_SHA::7}
+          if [ "${GITHUB_REF_NAME}" = "main" ]; then
+            echo "TAG1=${SHA}" >> $GITHUB_OUTPUT
+            echo "TAG2=latest" >> $GITHUB_OUTPUT
+          else
+            echo "TAG1=${SHA}-dev" >> $GITHUB_OUTPUT
+            echo "TAG2=dev" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build & push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: infra/Dockerfile
+          push: true
+          build-args: |
+            BUILD_DIR=${{ steps.detect.outputs.BUILD_DIR }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tags.outputs.TAG1 }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tags.outputs.TAG2 }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: ci
+on:
+  pull_request:
+  push:
+    branches: [main, dev]
+
+jobs:
+  build:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci || npm install
+      - run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,5 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'npm'
       - run: npm ci || npm install
       - run: npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,59 @@
+name: deploy
+on:
+  push:
+    branches: [main, dev]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Ensure folders and acme.json
+        run: |
+          sudo mkdir -p /opt/velocity-site/traefik/letsencrypt
+          sudo touch /opt/velocity-site/traefik/letsencrypt/acme.json
+          sudo chmod 600 /opt/velocity-site/traefik/letsencrypt/acme.json
+
+      - name: Sync infra to /opt/velocity-site
+        run: sudo rsync -a --delete infra/ /opt/velocity-site/
+
+      - name: GHCR login (for docker compose pull)
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Compute tags for compose
+        id: vars
+        run: |
+          SHA=${GITHUB_SHA::7}
+          if [ "${GITHUB_REF_NAME}" = "main" ]; then
+            echo "GIT_TAG_PROD=latest" >> $GITHUB_OUTPUT
+            echo "GIT_TAG_DEV=dev" >> $GITHUB_OUTPUT
+          else
+            echo "GIT_TAG_PROD=latest" >> $GITHUB_OUTPUT
+            echo "GIT_TAG_DEV=dev" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Deploy (docker compose up -d)
+        working-directory: /opt/velocity-site
+        env:
+          # для traefik:
+          ACME_EMAIL: ${{ secrets.ACME_EMAIL }}
+          # для basic-auth dev:
+          DEV_BASIC_AUTH_BCRYPT: ${{ secrets.DEV_BASIC_AUTH_BCRYPT }}
+          # для image-меток:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GIT_TAG_PROD: ${{ steps.vars.outputs.GIT_TAG_PROD }}
+          GIT_TAG_DEV: ${{ steps.vars.outputs.GIT_TAG_DEV }}
+        run: |
+          docker compose pull || true
+          docker compose up -d
+          docker system prune -f

--- a/README-deploy.md
+++ b/README-deploy.md
@@ -1,0 +1,25 @@
+# Deployment Pipeline
+
+This repository uses GitHub Actions and a self-hosted runner to build and deploy the site.
+
+## Workflows
+
+- **ci.yml** – runs build checks on pull requests and pushes to `main` or `dev`.
+- **build.yml** – builds a Docker image and publishes it to GHCR.
+- **deploy.yml** – pulls the image and runs `docker compose` on the server.
+
+## Secrets
+
+Configure repository secrets:
+
+- `GHCR_USERNAME`
+- `GHCR_TOKEN`
+- `ACME_EMAIL`
+- `DEV_BASIC_AUTH_BCRYPT`
+
+## Usage
+
+- Push to `dev` to deploy https://dev.leanwebstudio.ru (requires basic auth).
+- Push to `main` to deploy https://leanwebstudio.ru.
+
+Run `scripts/dev-basic-auth.sh` to generate a bcrypt hash for basic auth.

--- a/infra/Dockerfile
+++ b/infra/Dockerfile
@@ -1,0 +1,41 @@
+# Stage 1: build
+FROM node:20-alpine AS build
+WORKDIR /app
+
+# ускорение сборки: включаем corepack для yarn/pnpm
+RUN corepack enable || true
+
+COPY package.json ./
+# если есть lock-файл, копируем его
+COPY package-lock.json* yarn.lock* pnpm-lock.yaml* ./
+
+# установка deps
+RUN if [ -f pnpm-lock.yaml ]; then \
+      corepack enable pnpm && pnpm i --frozen-lockfile; \
+    elif [ -f yarn.lock ]; then \
+      corepack enable yarn && yarn install --frozen-lockfile; \
+    else \
+      npm ci || npm install; \
+    fi
+
+# копируем исходники
+COPY . .
+
+# билд (универсально)
+RUN if [ -f pnpm-lock.yaml ]; then pnpm build; \
+    elif [ -f yarn.lock ]; then yarn build; \
+    else npm run build; fi
+
+# Stage 2: serve static
+FROM nginx:alpine
+# Директория билда передается как ARG (dist|build)
+ARG BUILD_DIR=dist
+ENV BUILD_DIR=${BUILD_DIR}
+
+# nginx конфиг (SPA + кеш ассетов)
+RUN rm -f /etc/nginx/conf.d/default.conf
+COPY infra/nginx.conf /etc/nginx/conf.d/site.conf
+
+# Копируем артефакты (dist или build)
+COPY --from=build /app/${BUILD_DIR} /usr/share/nginx/html
+EXPOSE 80

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,48 @@
+version: "3.9"
+name: velocity-site
+
+services:
+  traefik:
+    image: traefik:v3.0
+    command:
+      - --entrypoints.web.address=:80
+      - --entrypoints.websecure.address=:443
+      - --providers.docker=true
+      - --providers.file.filename=/etc/traefik/dynamic.yml
+      - --certificatesresolvers.letsencrypt.acme.email=${ACME_EMAIL}
+      - --certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json
+      - --certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web
+      - --api=false
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./traefik/dynamic.yml:/etc/traefik/dynamic.yml:ro
+      - /opt/velocity-site/traefik/letsencrypt:/letsencrypt
+    restart: unless-stopped
+
+  site-prod:
+    image: ghcr.io/${GITHUB_REPOSITORY}:${GIT_TAG_PROD:-latest}
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.site-prod.rule=Host(`leanwebstudio.ru`,`www.leanwebstudio.ru`)"
+      - "traefik.http.routers.site-prod.entrypoints=websecure"
+      - "traefik.http.routers.site-prod.tls.certresolver=letsencrypt"
+      - "traefik.http.services.site-prod.loadbalancer.server.port=80"
+    depends_on: [traefik]
+    restart: unless-stopped
+
+  site-dev:
+    image: ghcr.io/${GITHUB_REPOSITORY}:${GIT_TAG_DEV:-dev}
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.site-dev.rule=Host(`dev.leanwebstudio.ru`)"
+      - "traefik.http.routers.site-dev.entrypoints=websecure"
+      - "traefik.http.routers.site-dev.tls.certresolver=letsencrypt"
+      # middleware basic-auth задаём прямо в labels через env:
+      - "traefik.http.middlewares.dev-auth.basicauth.users=${DEV_BASIC_AUTH_BCRYPT}"
+      - "traefik.http.routers.site-dev.middlewares=dev-auth@docker"
+      - "traefik.http.services.site-dev.loadbalancer.server.port=80"
+    depends_on: [traefik]
+    restart: unless-stopped

--- a/infra/nginx.conf
+++ b/infra/nginx.conf
@@ -1,0 +1,16 @@
+server {
+  listen 80;
+  server_name _;
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location / {
+    try_files $uri /index.html;
+  }
+
+  location ~* \.(?:js|css|ico|png|jpg|jpeg|svg|woff2?)$ {
+    try_files $uri =404;
+    access_log off;
+    add_header Cache-Control "public, max-age=31536000, immutable";
+  }
+}

--- a/infra/traefik/dynamic.yml
+++ b/infra/traefik/dynamic.yml
@@ -1,0 +1,13 @@
+http:
+  middlewares:
+    redirect-https:
+      redirectScheme:
+        scheme: https
+        permanent: true
+
+  routers:
+    redirect:
+      rule: "HostRegexp(`{host:.+}`)"
+      entryPoints: [web]
+      service: noop@internal
+      middlewares: [redirect-https]

--- a/scripts/dev-basic-auth.sh
+++ b/scripts/dev-basic-auth.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+if ! command -v htpasswd >/dev/null 2>&1; then
+  echo "htpasswd not installed" >&2
+  exit 1
+fi
+
+user=$1
+password=$2
+if [ -z "$user" ] || [ -z "$password" ]; then
+  echo "usage: $0 <user> <password>" >&2
+  exit 1
+fi
+
+htpasswd -nbB "$user" "$password"


### PR DESCRIPTION
## Summary
- build site image via multi-stage Dockerfile and serve with Traefik and nginx
- run CI build checks and publish images to GHCR
- deploy via docker compose on self-hosted runner
- document deployment and provide basic auth helper script

## Testing
- `npm test` *(fails: ENOENT no such file or directory, open '/workspace/lws/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_689ce015d85c8324a45b0ebf1f6dabfb