### PR TITLE
Add CoreDNS deployment via GitOps

### DIFF
--- a/.github/workflows/deploy-coredns.yml
+++ b/.github/workflows/deploy-coredns.yml
@@ -1,0 +1,46 @@
+name: Deploy CoreDNS
+
+on:
+  push:
+    branches: [dev, main]
+    paths:
+      - 'dns/**'
+  workflow_dispatch:
+
+concurrency:
+  group: coredns-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: self-hosted
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          clean: false
+
+      - name: Precheck port 53
+        run: |
+          sudo ss -u -lpn | grep ':53' || echo "UDP 53 free"
+          sudo ss -t -lpn | grep ':53' || echo "TCP 53 free"
+
+      - name: Pull image
+        working-directory: dns
+        run: docker compose pull
+
+      - name: Up CoreDNS
+        working-directory: dns
+        run: docker compose up -d --remove-orphans
+
+      - name: Smoke test (local)
+        run: |
+          sleep 2
+          dig @127.0.0.1 dev.leanwebstudio.ru A +short
+          dig @127.0.0.1 leanwebstudio.ru A +short
+          dig @127.0.0.1 ns1.leanwebstudio.ru A +short
+
+      - name: Logs tail on failure
+        if: failure()
+        run: docker logs --tail=200 coredns || true

--- a/dns/Corefile
+++ b/dns/Corefile
@@ -1,0 +1,9 @@
+.:53 {
+  # Авторитетная зона из файла
+  file /zones/leanwebstudio.zone leanwebstudio.ru
+
+  # Удобные лог/ошибки и hot-reload при изменении файлов
+  log
+  errors
+  reload
+}

--- a/dns/docker-compose.yml
+++ b/dns/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  coredns:
+    image: coredns/coredns:latest
+    container_name: coredns
+    restart: unless-stopped
+    # Важно: на хосте 53 должен быть свободен
+    ports:
+      - "53:53/udp"
+      - "53:53/tcp"
+    volumes:
+      - ./Corefile:/Corefile:ro
+      - ./zones:/zones:ro
+    # Если хочешь логи сразу в stdout
+    # command: ["-conf", "/Corefile"]

--- a/dns/zones/leanwebstudio.zone
+++ b/dns/zones/leanwebstudio.zone
@@ -1,0 +1,22 @@
+$ORIGIN leanwebstudio.ru.
+$TTL 300
+
+@     IN SOA ns1.leanwebstudio.ru. admin.leanwebstudio.ru. (
+        2025081501 ; serial  (меняй при каждом коммите зоны)
+        3600       ; refresh
+        1800       ; retry
+        604800     ; expire
+        300        ; minimum
+)
+
+      IN NS ns1.leanwebstudio.ru.
+
+; CoreDNS сам является ns1 (наш сервер)
+ns1   IN A 103.228.168.74
+
+; Корневая запись домена (прод)
+@     IN A 103.228.168.74
+www   IN CNAME @
+
+; Dev поддомен (указывает на тот же сервер)
+dev   IN A 103.228.168.74


### PR DESCRIPTION
## Summary
- Add CoreDNS configuration, zone file, and docker-compose
- Set up GitHub Actions workflow for automatic CoreDNS deployment

## Testing
- `named-checkzone leanwebstudio.ru dns/zones/leanwebstudio.zone`
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c751ef7083248af66d389e9f9f29