### PR TITLE
chore: track local .gitignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 **/.env
 **/*.env
 **/.DS_Store
-.gitignore
 # 🐳 Исключаем Docker build-артефакты
 *.tar
 *.pid


### PR DESCRIPTION
## Summary
- remove `.gitignore` from ignore list so nested ignore files can be tracked

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a36243088c8324bdc3ea70164c1244