### PR TITLE
chore: rename prod service to velocity-prod

### DIFF
--- a/prod-frontend/docker-compose.yml
+++ b/prod-frontend/docker-compose.yml
@@ -1,9 +1,9 @@
 services:
-  velocity-dev:
+  velocity-prod:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: velocity-dev
+    container_name: velocity-prod
     restart: unless-stopped
     networks:
       - npm-network


### PR DESCRIPTION
## Summary
- rename prod service and container to `velocity-prod`
- ensure CI already uses `velocity-prod`

## Testing
- `docker compose -f prod-frontend/docker-compose.yml config` *(fails: command not found)*
- `npm run lint` *(fails: 17 errors, 10 warnings)*
- `npm test` *(fails: missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_68a36229d1d883248a1c3dcbe8c1c739