### PR TITLE
Enable strict TypeScript checks

### DIFF
--- a/dev-frontend/src/components/HeroContactModal.tsx
+++ b/dev-frontend/src/components/HeroContactModal.tsx
@@ -4,7 +4,7 @@ import { useContactModal } from '@/hooks/useContactModal';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, type InputHTMLAttributes } from 'react';
 import { toast } from '@/hooks/use-toast';
 import InputMask from 'react-input-mask';
 import { supabase } from '@/integrations/supabase/client';
@@ -115,7 +115,7 @@ export const HeroContactModal = ({ language }: HeroContactModalProps) => {
 
   const validatePhone = (phone: string) => {
     // Убираем все пробелы, скобки и дефисы для проверки
-    const cleanPhone = phone.replace(/[\s\(\)\-]/g, '');
+    const cleanPhone = phone.replace(/[\s()-]/g, '');
     const phoneRegex = language === 'ru' ? /^(\+7|8)\d{10}$/ : /^(\+1)?\d{10}$/;
     return phoneRegex.test(cleanPhone);
   };
@@ -333,7 +333,7 @@ export const HeroContactModal = ({ language }: HeroContactModalProps) => {
                           maskChar="_"
                           value={formData.phone}
                           onChange={(e) => setFormData({ ...formData, phone: e.target.value })}
-                          children={(inputProps: any) => (
+                          children={(inputProps: InputHTMLAttributes<HTMLInputElement>) => (
                             <Input
                               {...inputProps}
                               id="phone"

--- a/dev-frontend/src/components/calculator/CalculatorContactForm.tsx
+++ b/dev-frontend/src/components/calculator/CalculatorContactForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, type InputHTMLAttributes } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
@@ -114,7 +114,7 @@ export const CalculatorContactForm = ({
 
   const validatePhone = (phone: string) => {
     // Убираем все пробелы, скобки и тире для проверки
-    const cleanPhone = phone.replace(/[\s\(\)\-]/g, '');
+    const cleanPhone = phone.replace(/[\s()-]/g, '');
     const phoneRegex = language === 'ru' ? /^(\+7|8)\d{10}$/ : /^(\+1)?\d{10}$/;
     console.log('Валидация телефона:', { phone, cleanPhone, isValid: phoneRegex.test(cleanPhone) });
     return phoneRegex.test(cleanPhone);
@@ -233,7 +233,7 @@ export const CalculatorContactForm = ({
                     maskChar="_"
                     value={formData.phone}
                     onChange={(e) => setFormData({ ...formData, phone: e.target.value })}
-                    children={(inputProps: any) => (
+                    children={(inputProps: InputHTMLAttributes<HTMLInputElement>) => (
                       <Input
                         {...inputProps}
                         type="tel"

--- a/dev-frontend/src/components/ui/command.tsx
+++ b/dev-frontend/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/dev-frontend/src/components/ui/textarea.tsx
+++ b/dev-frontend/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/dev-frontend/src/hooks/useAuth.tsx
+++ b/dev-frontend/src/hooks/useAuth.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, createContext, useContext } from 'react';
-import { User, Session } from '@supabase/supabase-js';
+import { User, Session, AuthError } from '@supabase/supabase-js';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 
@@ -18,8 +18,8 @@ interface AuthContextType {
   session: Session | null;
   profile: Profile | null;
   loading: boolean;
-  signIn: (email: string, password: string) => Promise<{ error: any }>;
-  signUp: (email: string, password: string, fullName: string) => Promise<{ error: any }>;
+  signIn: (email: string, password: string) => Promise<{ error: AuthError | null }>;
+  signUp: (email: string, password: string, fullName: string) => Promise<{ error: AuthError | null }>;
   signOut: () => Promise<void>;
   isAdmin: boolean;
 }

--- a/dev-frontend/src/pages/Index.tsx
+++ b/dev-frontend/src/pages/Index.tsx
@@ -4,7 +4,7 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import { ChevronDown, ArrowRight, Play, CheckCircle, Globe, Users, Star, ChevronLeft, ChevronRight, Menu, X } from "lucide-react";
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, type InputHTMLAttributes } from "react";
 import { useTypewriter } from '@/hooks/useTypewriter';
 import { CaseCard, DesktopCaseCard } from "@/components/CaseCard";
 import InputMask from "react-input-mask";
@@ -674,7 +674,7 @@ const Index = () => {
                     maskChar="_"
                     value={formData.phone}
                     onChange={(e) => setFormData(prev => ({ ...prev, phone: e.target.value }))}
-                    children={(inputProps: any) => (
+                    children={(inputProps: InputHTMLAttributes<HTMLInputElement>) => (
                       <Input
                         {...inputProps}
                         type="tel"

--- a/dev-frontend/src/pages/admin/CalculatorSettings.tsx
+++ b/dev-frontend/src/pages/admin/CalculatorSettings.tsx
@@ -9,12 +9,24 @@ import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 import { Pencil, Save, X } from 'lucide-react';
 
+interface ComplexityMultipliers {
+  simple: number;
+  medium: number;
+  complex: number;
+}
+
+interface TimelineMultipliers {
+  urgent: number;
+  normal: number;
+  flexible: number;
+}
+
 interface CalculatorSetting {
   id: string;
   project_type: string;
   base_price: number;
-  complexity_multipliers: any;
-  timeline_multipliers: any;
+  complexity_multipliers: ComplexityMultipliers;
+  timeline_multipliers: TimelineMultipliers;
   feature_price: number;
   is_active: boolean;
 }

--- a/dev-frontend/supabase/functions/send-email/index.ts
+++ b/dev-frontend/supabase/functions/send-email/index.ts
@@ -82,10 +82,10 @@ const handler = async (req: Request): Promise<Response> => {
         ...corsHeaders,
       },
     });
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error("Error in send-email function:", error);
     return new Response(
-      JSON.stringify({ error: error.message }),
+      JSON.stringify({ error: error instanceof Error ? error.message : String(error) }),
       {
         status: 500,
         headers: { "Content-Type": "application/json", ...corsHeaders },

--- a/dev-frontend/tailwind.config.ts
+++ b/dev-frontend/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -106,5 +107,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;

--- a/dev-frontend/tsconfig.app.json
+++ b/dev-frontend/tsconfig.app.json
@@ -16,9 +16,10 @@
 
     /* Linting */
     "strict": false,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "noImplicitAny": false,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
     "noFallthroughCasesInSwitch": false,
 
     "baseUrl": ".",

--- a/dev-frontend/tsconfig.json
+++ b/dev-frontend/tsconfig.json
@@ -9,11 +9,10 @@
     "paths": {
       "@/*": ["./src/*"]
     },
-    "noImplicitAny": false,
-    "noUnusedParameters": false,
+    "noImplicitAny": true,
+    "noUnusedParameters": true,
     "skipLibCheck": true,
-    "allowJs": true,
-    "noUnusedLocals": false,
-    "strictNullChecks": false
+    "noUnusedLocals": true,
+    "strictNullChecks": true
   }
 }

--- a/dev-frontend/tsconfig.node.json
+++ b/dev-frontend/tsconfig.node.json
@@ -14,8 +14,10 @@
 
     /* Linting */
     "strict": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "strictNullChecks": true,
     "noFallthroughCasesInSwitch": true
   },
   "include": ["vite.config.ts"]


### PR DESCRIPTION
## Summary
- enforce strict typing and null checks across dev-frontend
- remove allowJs and clean up any usage
- fix lint issues and replace `require` with proper imports

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a362402c448324ad202b7e1d3b9854