### PR TITLE
refactor: harden frontend Docker image

### DIFF
--- a/prod-frontend/Dockerfile
+++ b/prod-frontend/Dockerfile
@@ -2,12 +2,35 @@
 FROM node:20-alpine AS build
 WORKDIR /app
 
-COPY package*.json bun.lockb* ./
-COPY . .
+ARG BUILD_VERSION
+ARG BUILD_TIME
+ENV BUILD_VERSION=${BUILD_VERSION}
+ENV BUILD_TIME=${BUILD_TIME}
 
-RUN npm ci && npm run build
+COPY package*.json bun.lockb* ./
+RUN npm ci --only=production
+
+COPY . .
+RUN npm run build \
+  && npm prune --production \
+  && npm cache clean --force
 
 # --- nginx stage ---
 FROM nginx:alpine
+
+ARG BUILD_VERSION
+ARG BUILD_TIME
+ENV BUILD_VERSION=${BUILD_VERSION}
+ENV BUILD_TIME=${BUILD_TIME}
+
 COPY --from=build /app/dist /usr/share/nginx/html
-EXPOSE 80
+
+RUN addgroup -S nginx && adduser -S -G nginx nginx \
+  && mkdir -p /var/cache/nginx /var/run \
+  && chown -R nginx:nginx /var/cache/nginx /var/run /usr/share/nginx/html \
+  && sed -i 's/listen       80;/listen       8080;/' /etc/nginx/conf.d/default.conf
+
+EXPOSE 8080
+USER nginx
+
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD wget -qO- http://localhost:8080/ || exit 1


### PR DESCRIPTION
## Summary
- optimize dependency install and cache cleanup in Docker build stage
- add build metadata args and run nginx as non-root with healthcheck

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aadce0f81c8324869e17d3c1767c76