### PR TITLE
feat: refresh brand color scheme

### DIFF
--- a/prod-frontend/public/favicon.svg
+++ b/prod-frontend/public/favicon.svg
@@ -15,8 +15,8 @@
   
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="32" y2="32" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#523DFA"/>
-      <stop offset="1" stop-color="#11AEFF"/>
+      <stop stop-color="#2563EB"/>
+      <stop offset="1" stop-color="#00C6FF"/>
     </linearGradient>
   </defs>
 </svg>

--- a/prod-frontend/src/assets/logo.svg
+++ b/prod-frontend/src/assets/logo.svg
@@ -4,8 +4,8 @@
 </g>
 <defs>
 <linearGradient id="paint0_linear_2785_567" x1="943.921" y1="207.59" x2="45.0705" y2="207.59" gradientUnits="userSpaceOnUse">
-<stop stop-color="#523DFA"/>
-<stop offset="1" stop-color="#11AEFF"/>
+<stop stop-color="#2563EB"/>
+<stop offset="1" stop-color="#00C6FF"/>
 </linearGradient>
 <clipPath id="clip0_2785_567">
 <rect width="1050.46" height="613.398" fill="white"/>

--- a/prod-frontend/src/index.css
+++ b/prod-frontend/src/index.css
@@ -18,9 +18,9 @@ All colors MUST be HSL.
     --popover-foreground: 223 84% 5%;
 
     /* Brand gradient colors */
-    --brand-start: 218 100% 63%; /* #246AFF */
-    --brand-end: 250 100% 62%; /* #4E3FFF */
-    --primary: 218 100% 63%;
+    --brand-start: 221 83% 53%; /* #2563EB */
+    --brand-end: 193 100% 50%; /* #00C6FF */
+    --primary: 221 83% 53%;
     --primary-foreground: 0 0% 100%;
 
     --secondary: 220 13% 96%;
@@ -37,7 +37,7 @@ All colors MUST be HSL.
 
     --border: 220 13% 91%;
     --input: 220 13% 91%;
-    --ring: 218 100% 63%;
+    --ring: 221 83% 53%;
 
     --radius: 0.75rem;
 
@@ -71,7 +71,7 @@ All colors MUST be HSL.
 
     --sidebar-border: 220 13% 91%;
 
-    --sidebar-ring: 217.2 91.2% 59.8%;
+    --sidebar-ring: 221 83% 53%;
   }
 
   .dark {
@@ -84,8 +84,8 @@ All colors MUST be HSL.
     --popover: 222.2 84% 4.9%;
     --popover-foreground: 210 40% 98%;
 
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
+    --primary: 221 83% 53%;
+    --primary-foreground: 0 0% 100%;
 
     --secondary: 217.2 32.6% 17.5%;
     --secondary-foreground: 210 40% 98%;
@@ -101,7 +101,7 @@ All colors MUST be HSL.
 
     --border: 217.2 32.6% 17.5%;
     --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
+    --ring: 221 83% 53%;
     --sidebar-background: 240 5.9% 10%;
     --sidebar-foreground: 240 4.8% 95.9%;
     --sidebar-primary: 224.3 76.3% 48%;
@@ -109,7 +109,7 @@ All colors MUST be HSL.
     --sidebar-accent: 240 3.7% 15.9%;
     --sidebar-accent-foreground: 240 4.8% 95.9%;
     --sidebar-border: 240 3.7% 15.9%;
-    --sidebar-ring: 217.2 91.2% 59.8%;
+    --sidebar-ring: 221 83% 53%;
   }
 }
 


### PR DESCRIPTION
## Summary
- update design system with saturated blue primary and cyan gradient
- align favicon and logo with refreshed palette

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, require imports)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0e936bb48324ae4af30430292e8a