### PR TITLE
feat: apply brand gradient background

### DIFF
--- a/prod-frontend/src/index.css
+++ b/prod-frontend/src/index.css
@@ -119,7 +119,8 @@ All colors MUST be HSL.
   }
 
   body {
-    @apply bg-background text-foreground font-inter;
+    @apply font-inter text-primary-foreground;
+    background: var(--gradient-brand);
   }
 
   /* Smooth scrolling */


### PR DESCRIPTION
## Summary
- use brand gradient as default page background for better logo harmony

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and require import errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab105f56b08324831f908018d71d84